### PR TITLE
Add User-Agent header to XML-RPC requests

### DIFF
--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -724,7 +724,7 @@ class WordpressClient
         $this->_setXmlrpcType($params);
         $this->_request        = xmlrpc_encode_request($method, $params, array('encoding' => 'UTF-8', 'escaping' => 'markup'));
         $body                  = "";
-        if (false && function_exists('curl_init'))
+        if (function_exists('curl_init'))
         {
             $body = $this->_requestWithCurl();
         }


### PR DESCRIPTION
As of last week, an undocumented change was made to WordPress.com blogs which prevented XML-RPC requests being accepted unless the User-Agent header was present (see discussion [here](http://en.forums.wordpress.com/topic/xml-rpc-failing-to-respond-to-post-requests-via-curl-in-php?replies=7#post-2003632)).

The [XML-RPC specification](http://xmlrpc.scripting.com/spec.html) itself does state that the User-Agent header is required. This PR adds a meaningful User-Agent header to both cURL and file requests.
