### PR TITLE
Decode response as UTF-8

### DIFF
--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -844,7 +844,7 @@ class WordpressClient
         {
             $body = $this->_requestWithFile();
         }
-        $response = xmlrpc_decode($body);
+        $response = xmlrpc_decode($body, "UTF-8");
         if (is_array($response) && xmlrpc_is_fault($response))
         {
             $this->_error = ("xmlrpc: {$response['faultString']} ({$response['faultCode']})");


### PR DESCRIPTION
When requesting UTF-8 data, you should decode as such. Optionally, you should make the request/response encoding configurable.