### PR TITLE
introduce protected method for accessing request body from WordpressClient subclass

### DIFF
--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -1059,4 +1059,9 @@ class WordpressClient
         return $callbacks;
     }
 
+    protected function getRequest()
+    {
+        return $this->_request;
+    }
+
 }


### PR DESCRIPTION
Sorry for the pull request spam. I just realised that there is no way to access the contents of _request, which is vital for subclassing WordpressClient. This patch adds a protected method to do just that.