### PR TITLE
Post to WP Multisite Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,131 +1,32 @@
 Wordpress XML-RPC PHP Client
 =======================
 
-[![Build Status](https://travis-ci.org/letrunghieu/wordpress-xmlrpc-client.svg?branch=master)](https://travis-ci.org/letrunghieu/wordpress-xmlrpc-client) [![Latest Stable Version](https://poser.pugx.org/hieu-le/wordpress-xmlrpc-client/v/stable.svg)](https://packagist.org/packages/hieu-le/wordpress-xmlrpc-client) [![Total Downloads](https://poser.pugx.org/hieu-le/wordpress-xmlrpc-client/downloads.svg)](https://packagist.org/packages/hieu-le/wordpress-xmlrpc-client) [![Latest Unstable Version](https://poser.pugx.org/hieu-le/wordpress-xmlrpc-client/v/unstable.svg)](https://packagist.org/packages/hieu-le/wordpress-xmlrpc-client) [![License](https://poser.pugx.org/hieu-le/wordpress-xmlrpc-client/license.svg)](https://packagist.org/packages/hieu-le/wordpress-xmlrpc-client)
-
-A PHP client for Wordpress websites that closely implement the [XML-RPC WordPress API](http://codex.Wordpress.org/XML-RPC_WordPress_API)
+A fork of Hieu Le's PHP client for Wordpress - extended to handle publishing to multisite networks
 
 Created by [Hieu Le](http://www.hieule.info)
 
 MIT licensed.
 
-Current version: 2.4.2
+Current version: 1.0
 
 
 ## Features
 
-* Full test suit built in supporting testing using your own Wordpress site.
-* ~~Support error logging to files with Monolog library.~~ Now, erros can be logged in a more felxible way via **error callbacks** (v 2.4.0)
-* Support UTF-8 content.
-* Closely implement the whole [XML-RPC WordPress API](http://codex.Wordpress.org/XML-RPC_WordPress_API).
-* Detail exception will be thrown when errors occurs.
-* (v2.2) Support proxy and http authentication.
-* (v2.2.1) Allow value of `DateTime` class to be convert correctly to `datetime.iso8601` XML-RPC type,
-* (v2.4.0) Support using custom User Agent string beside the default User Agent string.
-* (v2.4.0) Support callbacks on **sending** and **error** events
+* Support for multisite networks
+* For full list of features visit https://github.com/letrunghieu/wordpress-xmlrpc-client
 
 ## Installation
 
-~~You will need [Composer](https://getcomposer.org/) installed on your machine to use this library~~ [Composer](https://getcomposer.org/) now is not required but recommended. Verify that composer is installed by typing this command
+Run `composer require yipeecaiey/wordpress-xmlrpc-client` to install this package.
 
-```bash
-composer --version
-```
-
-Choose one of the following methods to install **Wordpress XML-RPC PHP Client**
-
-### Your project has used composer:
+OR
 
 Add this dependency into your `composer.json` file
 
 ```json
-"hieu-le/wordpress-xmlrpc-client":"~2.0"
+"yipeecaiey/wordpress-xmlrpc-client":"~1.0"
 ```
 
 After that, run `composer update` to install this package.
 
-### Your project does not use composer:
 
-Clone or download the archive of this package from [github](https://github.com/letrunghieu/Wordpress-xmlrpc-client/releases). Include all files in the `src` directory into your project and start using **Wordpress XML-RPC Client**. You have to update the code of this library manually if using it without Composer.
-
-Required PHP extension is `xmlrpc` extension. The `curl` extension is optional but recommended.
-
-
-## Usage
-
-All API call will be executed via an instance of the `WordpressClient` class. Since version 2.4.0, there is no mandatory parameters in the contructor. `endPoint`, `username`, and `password` can be updated anytime by calling `setCredentials` method. The last parameter in previous version contructor (which is an instance of `\Illuminate\Log\Writer` class) is deprecated and will be removed in the next major release. Below is an example of using this library:
-
-```php
-# Your Wordpress website is at: http://wp-website.com
-$endpoint = "http://wp-website.com/xmlrpc.php";
-
-# The Monolog logger instance
-$wpLog = new Monolog\Logger('wp-xmlrpc');
-
-# Create client instance
-$wpClient = new \HieuLe\WordpressXmlrpcClient\WordpressClient();
-# Log error
-$wpClient->onError(function($error, $event) use ($wpLog){
-    $wpLog->addError($error, $event);
-});
-
-# Set the credentials for the next requests
-$wpClient->setCredentials($endpoint, 'username', 'password');
-
-```
-
-If you have used logging feture of previous version of this library, you should update your code to use the new way of loggin as above, the Monolog instance can be replaced by any kinds of logging tool that you have.
-
-To use date time value, you must use an instance of `DateTime` class instead of a string.
-
-There will be 2 types of exception may be thrown from this library:
-
-  * `XmlrpcException`: this kind of exception will be thrown if there is an error when the server executing your request
-  * `NetworkException`: this kind of exception will be thrown if there is an error when transfer your request to server or when getting the response.
-
-For API reference, visit [Wordpress documentation](http://codex.Wordpress.org/XML-RPC_WordPress_API) or [Library API documentation](http://letrunghieu.github.io/wordpress-xmlrpc-client/api/index.html)
-
-## User Agent (since 2.4.0)
-
-The library use the default User Agent when contacting with Wordpress blogs. If you want to use onother one, pass your custom User Agent string into the `setUserAgent` method. If you passed a _falsy_ value (`null`, `false`, ...) the default one will be used (thank @WarrenMoore)
-
-## Callbacks and events (since 2.4.0)
-
-The library allow developers to listen on two events `Sending` and `Error`. You can add new closure as a callback for each events by calling `on<event>` method with the closure as parameter (see the `onError` example above).
-
-### `onSending($event)`
-
-This event is fired before each request is send to Wordpress blogs. `$event` is an array:
-
-- `event`: the name of the event, here is `sending`
-- `endpoint`: URL of the current endpoint
-- `username`: current username
-- `password`: current password
-- `method`: current XML-RPC method
-- `params`: parameters passed to the current method
-- `request`: the body of the current request which will be sent
-- `proxy`: current proxy config
-- `auth`: current http auth config
-
-### `onError($errorMessage, $event)`
-
-This event is fired when the library run into errors, before any exception thrown. `$errorMessage` is a string. `$event` is an array:
-
-- `event`: the name of the event, here is `sending`
-- `endpoint`: URL of the current endpoint
-- `request`: the body of the current request
-- `proxy`: current proxy config
-- `auth`: current http auth config
-
-
-## Unit testing
-
-By default, the project use recorded data as the default data for test suite. However, if you want to test with your own Wordpress installation, there are available options inside the `./tests/xmlrpc.yml` file:
-
-  * `endpoint`: the url of your Wordpress XML-RPC endpoint
-  * `admin_login`: the email or username of a user with the *Administrator* role
-  * `admin_password`: the password of the admin user
-  * `guest_login`: the email or username of a user with the *Subscriber* role
-  * `guest_password`: the password of the guest user
-
-After update the `./tests/xmlrpc.yml` file, run your test again.

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,21 @@
 {
-	"name": "hieu-le/wordpress-xmlrpc-client",
-	"description": "A PHP client for Wordpress websites that closely implement the XML-RPC WordPress API with full test suite built in",
-	"keywords": ["wordpress", "xmlrpc", "client", "remote", "api"],
+	"name": "yipeecaiey/wordpress-xmlrpc-client",
+	"description": "A fork of Hieu Le's PHP client for Wordpress - extended to handle publishing to multisite networks",
+	"keywords": ["wordpress", "xmlrpc", "client", "remote", "api", "multisite"],
 	"license": "MIT",
-	"authors": [
-		{
-			"name": "Hieu Le",
-			"email": "letrunghieu.cse09@gmail.com",
-			"homepage": "http://www.hieule.info"
-		}
-	],
+    "repositories": [
+      {
+        "type": "vcs",
+        "url": "https://github.com/yipeecaiey/wordpress-xmlrpc-client"
+      }
+    ],
 	"require": {
 		"php": ">=5.3.0",
-		"ext-xmlrpc": "*"
-	},
-	"require-dev": {
-		"phpunit/phpunit": "*",
-		"symfony/yaml": "2.*",
-		"php-vcr/php-vcr": "^1.0",
-		"php-vcr/phpunit-testlistener-vcr": "*",
-		"illuminate/support": "~4.0",
-		"codeclimate/php-test-reporter": "dev-master"
+		"hieu-le/wordpress-xmlrpc-client": "dev-master"
 	},
 	"autoload": {
 		"psr-4": {
 			"HieuLe\\WordpressXmlrpcClient\\": "src/"
 		}
-	},
-	"minimum-stability": "stable"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
 	"description": "A fork of Hieu Le's PHP client for Wordpress - extended to handle publishing to multisite networks",
 	"keywords": ["wordpress", "xmlrpc", "client", "remote", "api", "multisite"],
 	"license": "MIT",
+	"stable": "1.0",
     "repositories": [
       {
         "type": "vcs",

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-	"name": "yipeecaiey/wordpress-xmlrpc-client",
+	"name": "yipeecaiey/wordpress-xmlrpc-client-multisite",
 	"description": "A fork of Hieu Le's PHP client for Wordpress - extended to handle publishing to multisite networks",
 	"keywords": ["wordpress", "xmlrpc", "client", "remote", "api", "multisite"],
 	"license": "MIT",
     "repositories": [
       {
         "type": "vcs",
-        "url": "https://github.com/yipeecaiey/wordpress-xmlrpc-client"
+        "url": "https://github.com/yipeecaiey/wordpress-xmlrpc-client-multisite"
       }
     ],
 	"require": {
@@ -15,7 +15,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"HieuLe\\WordpressXmlrpcClient\\": "src/"
+			"Yipeecaiey\\WordpressXmlrpcClient\\": "src/"
 		}
 	}
 }

--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -282,12 +282,13 @@ class WordpressClient
      * @param array   $categorieIds the list of category ids
      * @param integer $thumbnailId  the thumbnail id
      * @param array   $content      the content array, see more at wordpress documentation
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return integer the new post id
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.newPost
      */
-    function newPost($title, $body, array $content = array())
+    function newPost($title, $body, array $content = array(), $blogId = 1)
     {
         $default                 = array(
             'post_type'   => 'post',
@@ -297,7 +298,7 @@ class WordpressClient
         $content['post_title']   = $title;
         $content['post_content'] = $body;
 
-        $params = array(1, $this->username, $this->password, $content);
+        $params = array($blogId, $this->username, $this->password, $content);
 
         return $this->sendRequest('wp.newPost', $params);
     }

--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -279,8 +279,6 @@ class WordpressClient
      *
      * @param string  $title        the post title
      * @param string  $body         the post body
-     * @param array   $categorieIds the list of category ids
-     * @param integer $thumbnailId  the thumbnail id
      * @param array   $content      the content array, see more at wordpress documentation
      * @param integer $blogId       the blog id, see more at wordpress documentation
      *
@@ -307,11 +305,7 @@ class WordpressClient
      * Edit an existing post of any registered post type.
      *
      * @param integer $postId       the id of selected post
-     * @param string  $title        the new title
-     * @param string  $body         the new body
-     * @param array   $categorieIds the new list of category ids
-     * @param integer $thumbnailId  the new thumbnail id
-     * @param array   $content      the advanced array
+     * @param array   $content      the content array, see more at wordpress documentation
      *
      * @return boolean
      *

--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -5,7 +5,7 @@ namespace HieuLe\WordpressXmlrpcClient;
 /**
  * A XML-RPC client that implement the {@link http://codex.wordpress.org/XML-RPC_WordPress_API Wordpress API}.
  *
- * @version 2.5.0
+ * @version 2.5.0.1
  *
  * @author  Hieu Le <http://www.hieule.info>
  *

--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -264,9 +264,9 @@ class WordpressClient
      * @return array array of struct
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.getPosts
      */
-    function getPosts(array $filters = array(), array $fields = array())
+    function getPosts(array $filters = array(), array $fields = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $filters);
+        $params = array($blogId, $this->username, $this->password, $filters);
         if (!empty($fields)) {
             $params[] = $fields;
         }
@@ -311,9 +311,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.editPost
      */
-    function editPost($postId, array $content)
+    function editPost($postId, array $content, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $postId, $content);
+        $params = array($blogId, $this->username, $this->password, $postId, $content);
 
         return $this->sendRequest('wp.editPost', $params);
     }
@@ -327,9 +327,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.deletePost
      */
-    function deletePost($postId)
+    function deletePost($postId, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $postId);
+        $params = array($blogId, $this->username, $this->password, $postId);
 
         return $this->sendRequest('wp.deletePost', $params);
     }
@@ -344,9 +344,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.getPostType
      */
-    function getPostType($postTypeName, array $fields = array())
+    function getPostType($postTypeName, array $fields = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $postTypeName, $fields);
+        $params = array($blogId, $this->username, $this->password, $postTypeName, $fields);
 
         return $this->sendRequest('wp.getPostType', $params);
     }
@@ -361,9 +361,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.getPostTypes
      */
-    function getPostTypes(array $filter = array(), array $fields = array())
+    function getPostTypes(array $filter = array(), array $fields = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $filter, $fields);
+        $params = array($blogId, $this->username, $this->password, $filter, $fields);
 
         return $this->sendRequest('wp.getPostTypes', $params);
     }
@@ -375,9 +375,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.getPostFormats
      */
-    function getPostFormats()
+    function getPostFormats($blogId = 1)
     {
-        $params = array(1, $this->username, $this->password);
+        $params = array($blogId, $this->username, $this->password);
 
         return $this->sendRequest('wp.getPostFormats', $params);
     }
@@ -389,9 +389,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.getPostStatusList
      */
-    function getPostStatusList()
+    function getPostStatusList($blogId = 1)
     {
-        $params = array(1, $this->username, $this->password);
+        $params = array($blogId, $this->username, $this->password);
 
         return $this->sendRequest('wp.getPostStatusList', $params);
     }
@@ -405,9 +405,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies#wp.getTaxonomy
      */
-    function getTaxonomy($taxonomy)
+    function getTaxonomy($taxonomy, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $taxonomy);
+        $params = array($blogId, $this->username, $this->password, $taxonomy);
 
         return $this->sendRequest('wp.getTaxonomy', $params);
     }
@@ -419,9 +419,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies#wp.getTaxonomies
      */
-    function getTaxonomies()
+    function getTaxonomies($blogId = 1)
     {
-        $params = array(1, $this->username, $this->password);
+        $params = array($blogId, $this->username, $this->password);
 
         return $this->sendRequest('wp.getTaxonomies', $params);
     }
@@ -436,9 +436,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies#wp.getTerm
      */
-    function getTerm($termId, $taxonomy)
+    function getTerm($termId, $taxonomy, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $taxonomy, $termId);
+        $params = array($blogId, $this->username, $this->password, $taxonomy, $termId);
 
         return $this->sendRequest('wp.getTerm', $params);
     }
@@ -453,9 +453,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies#wp.getTerms
      */
-    function getTerms($taxonomy, array $filter = array())
+    function getTerms($taxonomy, array $filter = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $taxonomy, $filter);
+        $params = array($blogId, $this->username, $this->password, $taxonomy, $filter);
 
         return $this->sendRequest('wp.getTerms', $params);
     }
@@ -473,7 +473,7 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies#wp.newTerm
      */
-    function newTerm($name, $taxomony, $slug = null, $description = null, $parentId = null)
+    function newTerm($name, $taxomony, $slug = null, $description = null, $parentId = null, $blogId = 1)
     {
         $content = array(
             'name'     => $name,
@@ -488,7 +488,7 @@ class WordpressClient
         if ($parentId) {
             $content['parent'] = $parentId;
         }
-        $params = array(1, $this->username, $this->password, $content);
+        $params = array($blogId, $this->username, $this->password, $content);
 
         return $this->sendRequest('wp.newTerm', $params);
     }
@@ -522,9 +522,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Taxonomies#wp.deleteTerm
      */
-    function deleteTerm($termId, $taxonomy)
+    function deleteTerm($termId, $taxonomy, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $taxonomy, $termId);
+        $params = array($blogId, $this->username, $this->password, $taxonomy, $termId);
 
         return $this->sendRequest('wp.deleteTerm', $params);
     }
@@ -538,9 +538,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaItem
      */
-    function getMediaItem($itemId)
+    function getMediaItem($itemId, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $itemId);
+        $params = array($blogId, $this->username, $this->password, $itemId);
 
         return $this->sendRequest('wp.getMediaItem', $params);
     }
@@ -554,9 +554,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.getMediaLibrary
      */
-    function getMediaLibrary(array $filter = array())
+    function getMediaLibrary(array $filter = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $filter);
+        $params = array($blogId, $this->username, $this->password, $filter);
 
         return $this->sendRequest('wp.getMediaLibrary', $params);
     }
@@ -574,7 +574,7 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Media#wp.uploadFile
      */
-    function uploadFile($name, $mime, $bits, $overwrite = null, $postId = null)
+    function uploadFile($name, $mime, $bits, $overwrite = null, $postId = null, $blogId = 1)
     {
         xmlrpc_set_type($bits, 'base64');
         $struct = array(
@@ -588,7 +588,7 @@ class WordpressClient
         if ($postId !== null) {
             $struct['post_id'] = (int)$postId;
         }
-        $params = array(1, $this->username, $this->password, $struct);
+        $params = array($blogId, $this->username, $this->password, $struct);
 
         return $this->sendRequest('wp.uploadFile', $params);
     }
@@ -602,9 +602,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.getCommentCount
      */
-    function getCommentCount($postId)
+    function getCommentCount($postId, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $postId);
+        $params = array($blogId, $this->username, $this->password, $postId);
 
         return $this->sendRequest('wp.getCommentCount', $params);
     }
@@ -618,9 +618,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.getComment
      */
-    function getComment($commentId)
+    function getComment($commentId, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $commentId);
+        $params = array($blogId, $this->username, $this->password, $commentId);
 
         return $this->sendRequest('wp.getComment', $params);
     }
@@ -634,9 +634,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.getComments
      */
-    function getComments(array $filter = array())
+    function getComments(array $filter = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $filter);
+        $params = array($blogId, $this->username, $this->password, $filter);
 
         return $this->sendRequest('wp.getComments', $params);
     }
@@ -651,9 +651,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.newComment
      */
-    function newComment($post_id, array $comment)
+    function newComment($post_id, array $comment, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $post_id, $comment);
+        $params = array($blogId, $this->username, $this->password, $post_id, $comment);
 
         return $this->sendRequest('wp.newComment', $params);
     }
@@ -668,9 +668,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.editComment
      */
-    function editComment($commentId, array $comment)
+    function editComment($commentId, array $comment, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $commentId, $comment);
+        $params = array($blogId, $this->username, $this->password, $commentId, $comment);
 
         return $this->sendRequest('wp.editComment', $params);
     }
@@ -684,9 +684,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.deleteComment
      */
-    function deleteComment($commentId)
+    function deleteComment($commentId, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $commentId);
+        $params = array($blogId, $this->username, $this->password, $commentId);
 
         return $this->sendRequest('wp.deleteComment', $params);
     }
@@ -698,9 +698,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.getCommentStatusList
      */
-    function getCommentStatusList()
+    function getCommentStatusList($blogId = 1)
     {
-        $params = array(1, $this->username, $this->password);
+        $params = array($blogId, $this->username, $this->password);
 
         return $this->sendRequest('wp.getCommentStatusList', $params);
     }
@@ -714,12 +714,12 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Options#wp.getOptions
      */
-    function getOptions(array $options = array())
+    function getOptions(array $options = array(), $blogId = 1)
     {
         if (empty($options)) {
-            $params = array(1, $this->username, $this->password);
+            $params = array($blogId, $this->username, $this->password);
         } else {
-            $params = array(1, $this->username, $this->password, $options);
+            $params = array($blogId, $this->username, $this->password, $options);
         }
 
         return $this->sendRequest('wp.getOptions', $params);
@@ -734,9 +734,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Options#wp.setOptions
      */
-    function setOptions(array $options)
+    function setOptions(array $options, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $options);
+        $params = array($blogId, $this->username, $this->password, $options);
 
         return $this->sendRequest('wp.setOptions', $params);
     }
@@ -765,9 +765,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Users#wp.getUser
      */
-    function getUser($userId, array $fields = array())
+    function getUser($userId, array $fields = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $userId);
+        $params = array($blogId, $this->username, $this->password, $userId);
         if (!empty($fields)) {
             $params[] = $fields;
         }
@@ -785,9 +785,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Users#wp.getUsers
      */
-    function getUsers(array $filters = array(), array $fields = array())
+    function getUsers(array $filters = array(), array $fields = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $filters);
+        $params = array($blogId, $this->username, $this->password, $filters);
         if (!empty($fields)) {
             $params[] = $fields;
         }
@@ -804,9 +804,9 @@ class WordpressClient
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Users#wp.getProfile
      */
-    function getProfile(array $fields = array())
+    function getProfile(array $fields = array(), $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password);
+        $params = array($blogId, $this->username, $this->password);
         if (!empty($fields)) {
             $params[] = $fields;
         }
@@ -823,9 +823,9 @@ class WordpressClient
      *
      * http://codex.wordpress.org/XML-RPC_WordPress_API/Users#wp.editProfile
      */
-    function editProfile(array $content)
+    function editProfile(array $content, $blogId = 1)
     {
-        $params = array(1, $this->username, $this->password, $content);
+        $params = array($blogId, $this->username, $this->password, $content);
 
         return $this->sendRequest('wp.editProfile', $params);
     }

--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -258,8 +258,9 @@ class WordpressClient
     /**
      * Retrieve list of posts of any registered post type.
      *
-     * @param array $filters optional
-     * @param array $fields  optional
+     * @param array   $filters      optional
+     * @param array   $fields       optional
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array array of struct
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.getPosts
@@ -306,6 +307,7 @@ class WordpressClient
      *
      * @param integer $postId       the id of selected post
      * @param array   $content      the content array, see more at wordpress documentation
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return boolean
      *
@@ -321,7 +323,8 @@ class WordpressClient
     /**
      * Delete an existing post of any registered post type.
      *
-     * @param integer $postId the id of selected post
+     * @param integer $postId       the id of selected post
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return boolean
      *
@@ -337,8 +340,9 @@ class WordpressClient
     /**
      * Retrieve a registered post type.
      *
-     * @param string $postTypeName the post type name
-     * @param array  $fields       (optional) list of field or meta-field names to include in response.
+     * @param string  $postTypeName the post type name
+     * @param array   $fields       (optional) list of field or meta-field names to include in response.
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -354,8 +358,9 @@ class WordpressClient
     /**
      * Retrieve list of registered post types.
      *
-     * @param array $filter
-     * @param array $fields
+     * @param array   $filter
+     * @param array   $fields
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array    list of struct
      *
@@ -371,6 +376,8 @@ class WordpressClient
     /**
      * Retrieve list of post formats.
      *
+     * @param integer $blogId       the blog id, see more at wordpress documentation
+     *
      * @return array
      *
      * @link http://codex.wordpress.org/XML-RPC_WordPress_API/Posts#wp.getPostFormats
@@ -384,6 +391,8 @@ class WordpressClient
 
     /**
      * Retrieve list of supported values for post_status field on posts.
+     *
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array    list of supported post status
      *
@@ -399,7 +408,8 @@ class WordpressClient
     /**
      * Retrieve information about a taxonomy.
      *
-     * @param string $taxonomy the name of the selected taxonomy
+     * @param string  $taxonomy     the name of the selected taxonomy
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array    taxonomy information
      *
@@ -414,6 +424,8 @@ class WordpressClient
 
     /**
      * Retrieve a list of taxonomies.
+     *
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array array of taxonomy struct
      *
@@ -431,6 +443,7 @@ class WordpressClient
      *
      * @param integer $termId
      * @param string  $taxonomy
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -446,8 +459,9 @@ class WordpressClient
     /**
      * Retrieve list of terms in a taxonomy.
      *
-     * @param string $taxonomy
-     * @param array  $filter
+     * @param string  $taxonomy
+     * @param array   $filter
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -468,6 +482,7 @@ class WordpressClient
      * @param string  $slug
      * @param string  $description
      * @param integer $parentId
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return integer new term id
      *
@@ -517,6 +532,7 @@ class WordpressClient
      *
      * @param integer $termId
      * @param string  $taxonomy
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return boolean
      *
@@ -533,6 +549,7 @@ class WordpressClient
      * Retrieve a media item (i.e, attachment).
      *
      * @param integer $itemId
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -548,7 +565,8 @@ class WordpressClient
     /**
      * Retrieve list of media items.
      *
-     * @param array $filter
+     * @param array   $filter
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -564,11 +582,12 @@ class WordpressClient
     /**
      * Upload a media file.
      *
-     * @param string  $name      file name
-     * @param string  $mime      file mime type
-     * @param string  $bits      binary data (no encoded)
-     * @param boolean $overwrite (optional)
-     * @param int     $postId    (optional)
+     * @param string  $name         file name
+     * @param string  $mime         file mime type
+     * @param string  $bits         binary data (no encoded)
+     * @param boolean $overwrite    (optional)
+     * @param int     $postId       (optional)
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -597,6 +616,7 @@ class WordpressClient
      * Retrieve comment count for a specific post.
      *
      * @param integer $postId
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return integer
      *
@@ -613,6 +633,7 @@ class WordpressClient
      * Retrieve a comment.
      *
      * @param integer $commentId
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -628,7 +649,8 @@ class WordpressClient
     /**
      * Retrieve list of comments.
      *
-     * @param array $filter
+     * @param array   $filter
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -646,6 +668,7 @@ class WordpressClient
      *
      * @param integer $post_id
      * @param array   $comment
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return integer new comment_id
      *
@@ -663,6 +686,7 @@ class WordpressClient
      *
      * @param integer $commentId
      * @param array   $comment
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return boolean
      *
@@ -679,6 +703,7 @@ class WordpressClient
      * Remove an existing comment.
      *
      * @param integer $commentId
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return boolean
      *
@@ -693,6 +718,8 @@ class WordpressClient
 
     /**
      * Retrieve list of comment statuses.
+     *
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -709,6 +736,7 @@ class WordpressClient
      * Retrieve blog options.
      *
      * @param array $options
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -728,7 +756,8 @@ class WordpressClient
     /**
      * Edit blog options.
      *
-     * @param array $options
+     * @param array   $options
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -760,6 +789,7 @@ class WordpressClient
      *
      * @param integer $userId
      * @param array   $fields Optional. List of field or meta-field names to include in response.
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -778,8 +808,9 @@ class WordpressClient
     /**
      * Retrieve list of users.
      *
-     * @param array $filters
-     * @param array $fields
+     * @param array   $filters
+     * @param array   $fields
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -798,7 +829,8 @@ class WordpressClient
     /**
      * Retrieve profile of the requesting user.
      *
-     * @param array $fields
+     * @param array   $fields
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return array
      *
@@ -817,7 +849,8 @@ class WordpressClient
     /**
      * Edit profile of the requesting user.
      *
-     * @param array $content
+     * @param array   $content
+     * @param integer $blogId       the blog id, see more at wordpress documentation
      *
      * @return boolean
      *

--- a/src/WordpressClient.php
+++ b/src/WordpressClient.php
@@ -5,7 +5,7 @@ namespace HieuLe\WordpressXmlrpcClient;
 /**
  * A XML-RPC client that implement the {@link http://codex.wordpress.org/XML-RPC_WordPress_API Wordpress API}.
  *
- * @version 2.5.0.1
+ * @version 1.0
  *
  * @author  Hieu Le <http://www.hieule.info>
  *


### PR DESCRIPTION
I have added in optional $blogId parameter (default value ‘1’ for backwards compatibility) to all methods, allowing for posting to specific blogs within a multisite network.